### PR TITLE
add README files for the two shell languages

### DIFF
--- a/Bash/README.md
+++ b/Bash/README.md
@@ -1,0 +1,3 @@
+This folder has two samples of using the MCast™ API. The first sample, upload-raw-data.sh, demonstrates using the MCast™ API to upload new consumption data directly and then run a new forecast. The second sample, upload-data-file.sh, demonstrates using the MCast™ API to upload a file (formatted according to what MCast™ expects as worked out with your MEA support contact) to the MCast™ servers, which will automatically trigger a forecast. The second sample could be run on your own MCast™ instance by simply swapping in your own data file.
+
+Note that running either of these samples as-is won't actually make any changes on your MCast™ system, since the `dryRun` flag is set to `true`.

--- a/PowerShell/README.md
+++ b/PowerShell/README.md
@@ -1,0 +1,3 @@
+This folder has two samples of using the MCast™ API. The first sample, Send-RawData.ps1, demonstrates using the MCast™ API to upload new consumption data directly and then run a new forecast. The second sample, Send-DataFile.ps1, demonstrates using the MCast™ API to upload a file (formatted according to what MCast™ expects as worked out with your MEA support contact) to the MCast™ servers, which will automatically trigger a forecast. The second sample could be run on your own MCast™ instance by simply swapping in your own data file.
+
+Note that running either of these samples as-is won't actually make any changes on your MCast™ system, since the `dryRun` flag is set to `true`.


### PR DESCRIPTION
Jimmy pointed out that the 3 general purpose languages all have READMEs, but not the two shells, which seems like an oversight
