### PR TITLE
update Newtonsoft.Json to a full release version

### DIFF
--- a/CSharp/CSharp.csproj
+++ b/CSharp/CSharp.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Newtonsoft couldn't handle serialization of DateOnly at the time this was written except in a prerelease version.  I just want to update this to the latest normal version instead of having our sample rely on a prerelease.
